### PR TITLE
Bugfix #8 {% xlsmacro %} cannot call a macro defined in the same twig…

### DIFF
--- a/Tests/Resources/views/macro.twig
+++ b/Tests/Resources/views/macro.twig
@@ -8,4 +8,5 @@
         {{ macros.row('Hello2', 'World2') }}
     {% endxlssheet %}
     {{ macros.sheet('Test2', 'Hello3', 'World3') }}
+    {{ macros.sheet2('Test3', 'Hello4', 'World4') }}
 {% endxlsdocument %}

--- a/Tests/Resources/views/macroInclude.twig
+++ b/Tests/Resources/views/macroInclude.twig
@@ -21,3 +21,13 @@
         {% endxlsrow %}
     {% endxlssheet %}
 {% endxlsmacro %}
+
+{% xlsmacro sheet2(a, b, c) %}
+    {% from _self import cell %}
+    {% xlssheet a %}
+        {% xlsrow %}
+            {{ cell(b) }}
+            {{ cell(c) }}
+        {% endxlsrow %}
+    {% endxlssheet %}
+{% endxlsmacro %}

--- a/Tests/Twig/BasicTwigTest.php
+++ b/Tests/Twig/BasicTwigTest.php
@@ -179,6 +179,12 @@ class BasicTwigTest extends AbstractTwigTest
 
             static::assertEquals('Hello3', $sheet->getCell('A1')->getValue(), 'Unexpected value in A1');
             static::assertEquals('World3', $sheet->getCell('B1')->getValue(), 'Unexpected value in B1');
+
+            $sheet = $document->getSheetByName('Test3');
+            static::assertNotNull($sheet, 'Sheet does not exist');
+
+            static::assertEquals('Hello4', $sheet->getCell('A1')->getValue(), 'Unexpected value in A1');
+            static::assertEquals('World4', $sheet->getCell('B1')->getValue(), 'Unexpected value in B1');
         } catch (Twig_Error_Runtime $e) {
             static::fail($e->getMessage());
         }

--- a/Twig/TokenParser/XlsMacroTokenParser.php
+++ b/Twig/TokenParser/XlsMacroTokenParser.php
@@ -51,6 +51,9 @@ class XlsMacroTokenParser extends Twig_TokenParser_Macro
         // remove all unwanted text nodes
         NodeHelper::removeTextNodesRecursively($body, $this->parser);
 
+        // fix the methodCalls inside the body
+        NodeHelper::fixMacroCallsRecursively($body);
+
         $macro = new Twig_Node_Macro($name, new Twig_Node_Body(array($body)), $arguments, $lineno, $this->getTag());
 
         // mark for syntax checks


### PR DESCRIPTION
Fixed by using `NodeHelper::fixMacroCallsRecursively` on the body of each macro.
